### PR TITLE
Change index from virtual destructor to virtual Increment method.

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -117,7 +117,7 @@ double RunVirtualDirectCalls(int objCount, int runCount,
   }
 
   VoidMemberFn* updateFn = (VoidMemberFn*)(GetVTable(
-			dynamic_cast<IncrementerBase*>(objs[0])) + 0);
+			dynamic_cast<IncrementerBase*>(objs[0])) + 1);
 
   double runTime = 0;
   PerfTimer timer;


### PR DESCRIPTION
The ```updateFn``` member function point on virtual destructor instead of ```Increment``` virtual method.  When you run, it will throw **write access violation** exception on line 131.